### PR TITLE
Fixed bug where splicing static tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-tree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Behaviour tree for JS applications",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/staticTree.ts
+++ b/src/staticTree.ts
@@ -6,6 +6,7 @@ function traverse (actions: ActionFunc[], item: Chain | ParallelActions, isChain
 function traverse (actions: ActionFunc[], item: ActionFunc, outputs: ActionOutputs, isSync: boolean): ActionDescription
 function traverse (actions: ActionFunc[], item: any, isChain?: any, isSync?: boolean): any {
   if (Array.isArray(item) && typeof isChain === 'boolean') {
+    item = item.slice()
     return (item as Chain).map(function (subItem: ChainItem, index: number) {
       if (typeof subItem === 'function') {
         let nextSubItem = item[index + 1]


### PR DESCRIPTION
The static tree was splicing arrays of existing tree not allowing the signal to be executed twice :) So making a copy of array to keep splicing functionality as it is good, but now it does not break up the signal on first run
